### PR TITLE
jenkins_build.sh: Fetch meta-resin before checkout to not have old refs

### DIFF
--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -28,7 +28,9 @@ fi
 if [ "$metaResinBranch" == "__ignore__" ]; then
     echo "INFO: Using the default meta-resin revision (as configured in submodules)."
 else
+    echo "INFO: Using special meta-resin revision from build params."
     pushd $WORKSPACE/layers/meta-resin > /dev/null 2>&1
+    git fetch --all
     git checkout --force origin/$metaResinBranch
     popd > /dev/null 2>&1
 fi


### PR DESCRIPTION
Reviewers: @floion @telphan @Page-

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/resin-os/resin-yocto-scripts/1)
<!-- Reviewable:end -->
