### PR TITLE
Check for existence of npm, node and jq

### DIFF
--- a/build/barys
+++ b/build/barys
@@ -157,7 +157,7 @@ popd > /dev/null 2>&1
 SCRIPT_ARGUMENTS=$@
 
 # generate .json(s) from all the available .coffee files
-$SCRIPTPATH/build-device-type-json.sh
+$SCRIPTPATH/build-device-type-json.sh || log ERROR "Could not generate .json file(s)."
 
 # get all the device type .json files
 DEVICE_TYPES_JSONS=$(ls $SCRIPTPATH/../../*.json 2>/dev/null | grep -v package.json)
@@ -169,7 +169,7 @@ fi
 # Get the list of the supported machines out of all the available machine json files
 # (we may have multiple json files describing different machines based on the same resin layers; i.e. imx6 fsl based machines)
 for json in ${DEVICE_TYPES_JSONS}; do
-    SUPPORTED_MACHINES="${SUPPORTED_MACHINES} `jq -r "[.yocto.machine] | sort | .[] | select(. != null)" ${json}`"
+    SUPPORTED_MACHINES="${SUPPORTED_MACHINES} `jq -r "[.yocto.machine] | sort | .[] | select(. != null)" ${json} 2>/dev/null`" || log ERROR "Please install the 'jq' package before running this script."
 done
 
 # Parse arguments

--- a/build/build-device-type-json.sh
+++ b/build/build-device-type-json.sh
@@ -8,12 +8,18 @@ mydir=`dirname $0`
 
 cd $mydir/../../
 
+function quit {
+    rm -f "$slug".json
+    echo $0: $1 >&2
+    exit 1
+}
+
 for filename in *.coffee; do
     slug="${filename%.*}"
-    npm install coffee-script --production
+    npm install coffee-script --production 2>/dev/null || quit "ERROR - Please install the 'npm' package before running this script."
     cd ./resin-device-types && npm install --production && cd ..
 
-NODE_PATH=. node > "$slug".json << EOF
+{ NODE_PATH=. node > "$slug".json 2>/dev/null << EOF
     require('coffee-script/register');
     var dt = require('resin-device-types');
     var manifest = require('./${filename}');
@@ -21,4 +27,10 @@ NODE_PATH=. node > "$slug".json << EOF
     var builtManifest = dt.buildManifest(manifest, slug);
     console.log(JSON.stringify(builtManifest, null, '\t'));
 EOF
+} || quit "ERROR - Please install the 'nodejs' package before running this script."
+
+if [ ! -s "$slug".json ]; then
+    quit "ERROR - Please check your nodejs installation. The 'node' binary did not generate proper .json(s)."
+fi
+
 done


### PR DESCRIPTION
We need to display error messages when these commands are not available
and instruct the user to install them.

fixes #2 

Signed-off-by: Florin Sarbu <florin@resin.io>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/resin-os/resin-yocto-scripts/3)
<!-- Reviewable:end -->
