### PR TITLE
faster builds and also fixes #8

### DIFF
--- a/build/build-device-type-json.sh
+++ b/build/build-device-type-json.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
 # Usage:
-# ./build-device-type-json.sh
+# ./build-device-type-json.sh [directory]
 # this generates device-type-slug.json in the root of the resin-<board> directory
 
 mydir=`dirname $0`
+rootdir=$1 || $mydir/../../
 
-cd $mydir/../../
+cd $rootdir
 
 rm -f *.json
 
@@ -16,13 +17,13 @@ function quit {
     exit 1
 }
 
+(cd ./resin-device-types && npm install --production 1>/dev/null || quit "ERROR - Please install the 'npm' package before running this script.")
+
 for filename in *.coffee; do
     slug="${filename%.*}"
-    npm install coffee-script --production 2>/dev/null || quit "ERROR - Please install the 'npm' package before running this script."
-    cd ./resin-device-types && npm install --production && cd ..
 
 { NODE_PATH=. node > "$slug".json 2>/dev/null << EOF
-    require('coffee-script/register');
+    require('resin-device-types/node_modules/coffee-script/register');
     var dt = require('resin-device-types');
     var manifest = require('./${filename}');
     var slug = '${slug}';
@@ -34,5 +35,6 @@ EOF
 if [ ! -s "$slug".json ]; then
     quit "ERROR - Please check your nodejs installation. The 'node' binary did not generate proper .json(s)."
 fi
-
 done
+
+echo "Done"


### PR DESCRIPTION
What I did:
- optional param to build in the given directory
- hide npm install stdout
- _reuse_ coffee-script installed inside of the `resin-device-types` - faster and safer and should fix the issue

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/resin-os/resin-yocto-scripts/9)
<!-- Reviewable:end -->
