### PR TITLE
build-device-type-json.sh: make this work on ubuntu

### DIFF
--- a/build/build-device-type-json.sh
+++ b/build/build-device-type-json.sh
@@ -23,7 +23,8 @@ function quit {
 for filename in *.coffee; do
     slug="${filename%.*}"
 
-{ NODE_PATH=. node > "$slug".json 2>/dev/null << EOF
+which nodejs >/dev/null && NODE=nodejs || NODE=node
+{ NODE_PATH=. $NODE > "$slug".json 2>/dev/null << EOF
     require('resin-device-types/node_modules/coffee-script/register');
     var dt = require('resin-device-types');
     var manifest = require('./${filename}');
@@ -34,7 +35,7 @@ EOF
 } || quit "ERROR - Please install the 'nodejs' package before running this script."
 
 if [ ! -s "$slug".json ]; then
-    quit "ERROR - Please check your nodejs installation. The 'node' binary did not generate proper .json(s)."
+    quit "ERROR - Please check your nodejs installation. The '$NODE' binary did not generate a proper .json."
 fi
 done
 


### PR DESCRIPTION
Some package managers install nodejs as 'node', while others as
'nodejs'.

Also change the wording in the error message a little.

Signed-off-by: Michal Mazurek <michal@resin.io>