### PR TITLE
jenkins_build.sh: Deploy kernel_modules_headers.tar.bz2

### DIFF
--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -123,6 +123,8 @@ fi
 mv -v $WORKSPACE/build/tmp/deploy/images/$MACHINE/VERSION $BUILD_DEPLOY_DIR
 mv -v $WORKSPACE/build/tmp/deploy/images/$MACHINE/VERSION_HOSTOS $BUILD_DEPLOY_DIR
 cp $DEVICE_TYPE_JSON $BUILD_DEPLOY_DIR/device-type.json
+# move to deploy directory the kernel modules headers so we have it as a build artifact in jenkins
+mv -v $WORKSPACE/build/tmp/deploy/images/$MACHINE/kernel_modules_headers.tar.bz2 $BUILD_DEPLOY_DIR
 
 # Cleanup the build directory
 # Keep this after writing all artifacts


### PR DESCRIPTION
We need this archive exposed as a Jenkins build artifact

Signed-off-by: Florin Sarbu <florin@resin.io>