### PR TITLE
use npm deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.swp
 barys.log
+build/node_modules
+*.log

--- a/automation/Dockerfile_yocto-build-env
+++ b/automation/Dockerfile_yocto-build-env
@@ -4,10 +4,13 @@ FROM ubuntu:15.04
 RUN apt-get update && apt-get install -y build-essential chrpath curl diffstat gcc-multilib gawk git-core libsdl1.2-dev texinfo unzip wget xterm cpio file && rm -rf /var/lib/apt/lists/*
 
 # Additional host packages required by resin
-RUN apt-get update && apt-get install -y jq npm nodejs sudo && rm -rf /var/lib/apt/lists/*
-
-# Fix path of node/nodejs
-RUN ln -s /usr/bin/nodejs /usr/bin/node
+RUN apt-get update && apt-get install -y apt-transport-https && rm -rf /var/lib/apt/lists/*
+RUN curl --silent https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
+ENV NODE_VERSION node_4.x
+ENV DISTRO vivid
+RUN echo "deb https://deb.nodesource.com/$NODE_VERSION $DISTRO main" | tee /etc/apt/sources.list.d/nodesource.list &&\
+  echo "deb-src https://deb.nodesource.com/$NODE_VERSION $DISTRO main" | tee -a /etc/apt/sources.list.d/nodesource.list
+RUN apt-get update && apt-get install -y jq nodejs sudo && rm -rf /var/lib/apt/lists/*
 
 # Install docker
 # https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies

--- a/build/build-device-type-json.sh
+++ b/build/build-device-type-json.sh
@@ -5,12 +5,11 @@
 # this generates device-type-slug.json in the root of the resin-<board> directory
 # the directory can be passed as an optional argument, default is 2 levels higher than the script itself
 
-mydir=`dirname $0`
+echo "Building JSON manifest..."
+
+cd `dirname $0`
+mydir=`pwd -P`
 rootdir=${1:-$mydir/../../}
-
-cd $rootdir
-
-rm -f *.json
 
 function quit {
     rm -f "$slug".json
@@ -18,15 +17,18 @@ function quit {
     exit 1
 }
 
-(cd ./resin-device-types && npm install --production 1>/dev/null || quit "ERROR - Please install the 'npm' package before running this script.")
+npm install --production --silent >/dev/null || quit "ERROR - Please install the 'npm' package before running this script."
+
+which nodejs >/dev/null 2>&1 && NODE=nodejs || NODE=node
+
+cd $rootdir
+rm -f *.json
 
 for filename in *.coffee; do
     slug="${filename%.*}"
-
-which nodejs >/dev/null 2>&1 && NODE=nodejs || NODE=node
-{ NODE_PATH=. $NODE > "$slug".json 2>/dev/null << EOF
-    require('resin-device-types/node_modules/coffee-script/register');
-    var dt = require('resin-device-types');
+{ NODE_PATH=$mydir/node_modules $NODE > "$slug".json 2>/dev/null << EOF
+    require('coffee-script/register');
+    var dt = require('@resin.io/device-types');
     var manifest = require('./${filename}');
     var slug = '${slug}';
     var builtManifest = dt.buildManifest(manifest, slug);
@@ -39,4 +41,4 @@ if [ ! -s "$slug".json ]; then
 fi
 done
 
-echo "Done"
+echo "...Done"

--- a/build/package.json
+++ b/build/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "build-device-type-json",
+  "version": "1.0.0",
+  "description": "Dependencies for build-device-type-json.sh",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/resin-os/resin-yocto-scripts"
+  },
+  "author": "Resin.io <hello@resin.io>",
+  "license": "Unlicensed",
+  "dependencies": {
+    "@resin.io/device-types": "^10.1.0",
+    "coffee-script": "~1.10.0"
+  }
+}


### PR DESCRIPTION
That removes it as a submodule dependency and allows
automatically fetching the updated versions according to semver.

Signed-off-by: Eugene Mirotin <eugene@resin.io>