### PR TITLE
Add python3 to automation/Dockerfile_yocto-build-env

### DIFF
--- a/automation/Dockerfile_yocto-build-env
+++ b/automation/Dockerfile_yocto-build-env
@@ -1,7 +1,7 @@
 FROM ubuntu:15.04
 
 # Install the following utilities (required by poky)
-RUN apt-get update && apt-get install -y build-essential chrpath curl diffstat gcc-multilib gawk git-core libsdl1.2-dev texinfo unzip wget xterm cpio file && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y build-essential chrpath curl diffstat gcc-multilib gawk git-core libsdl1.2-dev texinfo unzip wget xterm cpio file python3 && rm -rf /var/lib/apt/lists/*
 
 # Additional host packages required by resin
 RUN apt-get update && apt-get install -y apt-transport-https && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This dependency is needed for newer builds based on poky which
has a dependency on python3.

Signed-off-by: Florin Sarbu <florin@resin.io>