### PR TITLE
Set the locale to UTF-8 for being able

### DIFF
--- a/automation/Dockerfile_yocto-build-env
+++ b/automation/Dockerfile_yocto-build-env
@@ -3,6 +3,10 @@ FROM ubuntu:15.04
 # Install the following utilities (required by poky)
 RUN apt-get update && apt-get install -y build-essential chrpath curl diffstat gcc-multilib gawk git-core libsdl1.2-dev texinfo unzip wget xterm cpio file python3 && rm -rf /var/lib/apt/lists/*
 
+# Set the locale to UTF-8 for bulding with poky morty
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+
 # Additional host packages required by resin
 RUN apt-get update && apt-get install -y apt-transport-https && rm -rf /var/lib/apt/lists/*
 RUN curl --silent https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -


### PR DESCRIPTION
to use with poky morty.

This fixes the following poky morty error:

Please use a locale setting which supports utf-8.
Python can't change the filesystem locale after loading so we need a utf-8 when python starts or things won't work.

Signed-off-by: Florin Sarbu <florin@resin.io>