### PR TITLE
jenkins_build.sh: Make sure the docker registry tags are valid

### DIFF
--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -139,9 +139,11 @@ if [[ "$sourceBranch" == production* ]] && [ "$metaResinBranch" == "__ignore__" 
     echo "INFO: Pushing resinhup package to dockerhub and registry.resinstaging.io."
     SLUG=$(jq --raw-output '.slug' $DEVICE_TYPE_JSON)
     DOCKER_REPO="resin/resinos"
-    DOCKER_TAG="$VERSION_HOSTOS-$SLUG"
     RESINREG_REPO="registry.resinstaging.io/resin/resinos"
-    RESINREG_TAG="$VERSION_HOSTOS-$SLUG"
+    # Make sure the tags are valid
+    # https://github.com/docker/docker/blob/master/vendor/github.com/docker/distribution/reference/regexp.go#L37
+    DOCKER_TAG="$(echo $VERSION_HOSTOS-$SLUG | sed 's/[^a-z0-9A-Z_.-]/_/g')"
+    RESINREG_TAG="$(echo $VERSION_HOSTOS-$SLUG | sed 's/[^a-z0-9A-Z_.-]/_/g')"
     if [ -f $BUILD_DEPLOY_DIR/resinhup-$VERSION_HOSTOS.tar ]; then
         docker import $BUILD_DEPLOY_DIR/resinhup-$VERSION_HOSTOS.tar $DOCKER_REPO:$DOCKER_TAG
         docker push $DOCKER_REPO:$DOCKER_TAG


### PR DESCRIPTION
The docker registry tags need to satisfy the following regex:
[\w][\w.-]{0,127}.
https://github.com/docker/docker/blob/master/vendor/github.com/docker/distribution/reference/regexp.go#L37

Make sure this is valid for our resinOS tags too.

Signed-off-by: Andrei Gherzan <andrei@resin.io>