### PR TITLE
jenkins_build.sh: Always locally create latest but upload it only for…

### DIFF
--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -222,8 +222,9 @@ if [ "$deploy" == "yes" ]; then
 		-e BUILD_VERSION="$S3_VERSION_HOSTOS" \
 		-e DEVELOPMENT_IMAGE="$DEVELOPMENT_IMAGE" \
 		-v $S3_DEPLOY_DIR:/host/images resin/resin-img:master /bin/sh -x -c ' \
-		([ "${DEVELOPMENT_IMAGE}" = "no" ] && echo "${BUILD_VERSION}" > "/host/images/${SLUG}/latest" && $S3_CMD put /host/images/${SLUG}/latest s3://${S3_BUCKET}/${SLUG}/ || true) \
+		echo "${BUILD_VERSION}" > "/host/images/${SLUG}/latest" \
 		&& /usr/src/app/node_modules/.bin/coffee /usr/src/app/scripts/prepare.coffee \
+		&& ([ "${DEVELOPMENT_IMAGE}" = "no" ] && $S3_CMD put /host/images/${SLUG}/latest s3://${S3_BUCKET}/${SLUG}/ || true) \
 		&& apt-get -y update \
 		&& apt-get install -y s3cmd \
 		&& ([ -z "$($S3_CMD ls s3://${S3_BUCKET}/${SLUG}/${BUILD_VERSION}/)" ] \


### PR DESCRIPTION
… nondev images

If latest doesn't exist the compressed partitions will not get
generated. So make sure it always exists but only push it if we are
deploying a non dev image.

Signed-off-by: Andrei Gherzan <andrei@resin.io>