### PR TITLE
Stop calling image-maker's `scripts/prepare.coffee` [ Blocked by resin-io/resin-image-maker#79 ]

### DIFF
--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -231,7 +231,6 @@ deploy_to_s3() {
 			useradd -m -u $DEPLOYER_UID -g $DEPLOYER_GID deployer
 			su deployer<<EOSU
 echo "${BUILD_VERSION}" > "/host/images/${SLUG}/latest"
-/usr/src/app/node_modules/.bin/coffee /usr/src/app/scripts/prepare.coffee
 if [ -z "$($S3_CMD ls s3://${S3_BUCKET}/${SLUG}/${BUILD_VERSION}/)" ]; then
 	touch /host/images/${SLUG}/${BUILD_VERSION}/IGNORE
 	$S3_CMD put /host/images/${SLUG}/${BUILD_VERSION}/IGNORE s3://${S3_BUCKET}/${SLUG}/${BUILD_VERSION}/


### PR DESCRIPTION
This is related to https://github.com/resin-io/resin-image-maker/pull/79
The image-maker no longer requires a `compressed` folder for the images.
The prepare.coffee script is no longer useful and is removed in the PR above.