### PR TITLE
automation/jenkins_build.sh: Simplify git checkout

### DIFF
--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -103,7 +103,7 @@ else
 	echo "[INFO] Using special meta-resin revision from build params."
 	pushd $WORKSPACE/layers/meta-resin > /dev/null 2>&1
 	git fetch --all
-	git checkout --force origin/$metaResinBranch
+	git checkout --force $metaResinBranch
 	popd > /dev/null 2>&1
 fi
 


### PR DESCRIPTION
Remove explicit use of origin namespace when checking out
meta-resin. If we want to specify a revision using a SHA1
this won't work so just simply git checkout $metaResinBranch.

Signed-off-by: Will Newton <willn@resin.io>