### PR TITLE
automation/jenkins_build.sh: Allow checkout of forked pull requests

### DIFF
--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -102,6 +102,7 @@ if [ "$metaResinBranch" = "__ignore__" ]; then
 else
 	echo "[INFO] Using special meta-resin revision from build params."
 	pushd $WORKSPACE/layers/meta-resin > /dev/null 2>&1
+	git config --add remote.origin.fetch '+refs/pull/*:refs/remotes/origin/pr/*'
 	git fetch --all
 	git checkout --force $metaResinBranch
 	popd > /dev/null 2>&1


### PR DESCRIPTION
When we checkout a meta-resin revision for building we must also take into
consideration that such a revision might be from an external contributor's
fork sent as a pull request.

Signed-off-by: Florin Sarbu <florin@resin.io>