### PR TITLE
barys: reset, don't append, additional variables

### DIFF
--- a/build/barys
+++ b/build/barys
@@ -422,6 +422,7 @@ else
     sed -i "s/.*DEVELOPMENT_IMAGE =.*/DEVELOPMENT_IMAGE = \"1\"/g" conf/local.conf
 fi
 
+perl -i -pe 'BEGIN {$/ = undef}; s/^\n# Barys: Additional variables.*//sm' conf/local.conf
 echo -e "\n# Barys: Additional variables" >> conf/local.conf
 for pair in $ADDITIONAL_VARIABLES; do
     variable=$(echo "$pair" | awk -F= '{print $1}')


### PR DESCRIPTION
Currently barys will append local variables to conf/local.conf each time
it's run, leading to a long repeated list after a couple of runs.

Clean it up before appending.

Signed-off-by: Michal Mazurek <michal@resin.io>