### PR TITLE
jenkins_build.sh: Copy recursively when dealing with archived build a…

### DIFF
--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -43,7 +43,7 @@ deploy_build () {
 	fi
 
 	if [ "${_archive}" = 'true' ]; then
-		cp -v "$YOCTO_BUILD_DEPLOY/$_deploy_artifact" "$_deploy_dir/image/$_deploy_artifact"
+		cp -rv "$YOCTO_BUILD_DEPLOY/$_deploy_artifact" "$_deploy_dir/image/"
 		(cd "$_deploy_dir/image/$_deploy_artifact" && zip -r "../$_deploy_artifact.zip" .)
 		if [ "$_remove_compressed_file" = "true" ]; then
 			rm -rf $_deploy_dir/image/$_deploy_artifact


### PR DESCRIPTION
…rtifacts

Archived build artifacts flagging means we are dealing with a directory so we
need to be able to copy recursively.

Signed-off-by: Florin Sarbu <florin@resin.io>