### PR TITLE
jenkins_build.sh: Copy just the contents of a directory

### DIFF
--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -43,7 +43,7 @@ deploy_build () {
 	fi
 
 	if [ "${_archive}" = 'true' ]; then
-		cp -rv "$YOCTO_BUILD_DEPLOY/$_deploy_artifact" "$_deploy_dir/image/"
+		cp -rv "$YOCTO_BUILD_DEPLOY/$_deploy_artifact/*" "$_deploy_dir/image/"
 		(cd "$_deploy_dir/image/$_deploy_artifact" && zip -r "../$_deploy_artifact.zip" .)
 		if [ "$_remove_compressed_file" = "true" ]; then
 			rm -rf $_deploy_dir/image/$_deploy_artifact


### PR DESCRIPTION
for an archived build, not the whole directory

The image maker expects the contents of the build dir artifacts to be in
$_deploy_dir/image/, not the entire directory with subdirectories.

Signed-off-by: Florin Sarbu <florin@resin.io>