### PR TITLE
jenkins_build.sh: Copy to path expected by the resin image maker

### DIFF
--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -43,10 +43,10 @@ deploy_build () {
 	fi
 
 	if [ "${_archive}" = 'true' ]; then
-		cp -rv "$YOCTO_BUILD_DEPLOY/$_deploy_artifact/*" "$_deploy_dir/image/"
-		(cd "$_deploy_dir/image/$_deploy_artifact" && zip -r "../$_deploy_artifact.zip" .)
+		cp -rv "$YOCTO_BUILD_DEPLOY"/"$_deploy_artifact"/* "$_deploy_dir"/image/
+		(cd "$_deploy_dir/image/" && zip -r "../$_deploy_artifact.zip" .)
 		if [ "$_remove_compressed_file" = "true" ]; then
-			rm -rf $_deploy_dir/image/$_deploy_artifact
+			rm -rf $_deploy_dir/image
 		fi
 	else
 		cp -v $(readlink --canonicalize "$YOCTO_BUILD_DEPLOY/$_deploy_artifact") "$_deploy_dir/image/resin.img"


### PR DESCRIPTION
Signed-off-by: Florin Sarbu <florin@resin.io>