### PR TITLE
Attempt to fix unrecognized input header error

### DIFF
--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -218,7 +218,7 @@ deploy_to_s3() {
 
 	local _s3_cmd="s3cmd --access_key=${_s3_access_key} --secret_key=${_s3_secret_key}"
 	local _s3_sync_opts="--recursive --acl-public"
-	docker run \
+	docker run -it \
 		-e BASE_DIR=/host/images \
 		-e S3_CMD="$_s3_cmd" \
 		-e S3_SYNC_OPTS="$_s3_sync_opts" \


### PR DESCRIPTION
Based on the threads listed below, this should resolve the issue, which
is related to building an image with the interactive terminal flag (-t)
but then running it without the flag.

https://github.com/moby/moby/pull/4882
https://github.com/moby/moby/issues/4857
https://github.com/moby/moby/issues/5327

Change-Type: patch