### PR TITLE
jenkins_build.sh: Remove pseudo tty allocation

### DIFF
--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -218,7 +218,7 @@ deploy_to_s3() {
 
 	local _s3_cmd="s3cmd --access_key=${_s3_access_key} --secret_key=${_s3_secret_key}"
 	local _s3_sync_opts="--recursive --acl-public"
-	docker run -it \
+	docker run --rm -t \
 		-e BASE_DIR=/host/images \
 		-e S3_CMD="$_s3_cmd" \
 		-e S3_SYNC_OPTS="$_s3_sync_opts" \


### PR DESCRIPTION
Having this arg for docker run produces the following error:
cannot enable tty mode on non tty input

Signed-off-by: Florin Sarbu <florin@resin.io>