### PR TITLE
jenkins_build.sh: Do not error out when deployment has been already done

### DIFF
--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -244,8 +244,7 @@ if [ -z "$($S3_CMD ls s3://${S3_BUCKET}/${SLUG}/${BUILD_VERSION}/)" ]; then
 		$S3_CMD put /host/images/${SLUG}/latest s3://${S3_BUCKET}/${SLUG}/
 	fi
 else
-	echo "Deployment already done for ${SLUG} at version ${BUILD_VERSION}"
-	exit 1
+	echo "WARNING: Deployment already done for ${SLUG} at version ${BUILD_VERSION}"
 fi
 EOSU
 		'


### PR DESCRIPTION
Currently we call this script from Jenkins 4 times in a row: for managed production build,
for managed development build, for unmanaged production build and for unmanaged development
build. For various reasons related to the Jenkins environment and not only, one of these builds
can fail. If the second, third or fourth of these builds fail, when retriggering the upstream
Jenkins job to redo the deployment it will error out on the code highlighted here complaining that
deployment is done. That should not be an error and it should only throw a warning and continue with
the rest of the downstream build jobs to finish deploying successfully all the resin build flavours

Signed-off-by: Florin Sarbu <florin@resin.io>