### PR TITLE
jenkins_yocto-build-env.sh: Invalidate cache when building the yocto-…

### DIFF
--- a/automation/jenkins_yocto-build-env.sh
+++ b/automation/jenkins_yocto-build-env.sh
@@ -20,7 +20,7 @@ if [ -z "${JOB_NAME}" ]; then
 fi
 
 # Build
-docker build --pull --tag resin/${JOB_NAME}:${REVISION} -f ${SCRIPTPATH}/${DOCKERFILE} ${SCRIPTPATH}
+docker build --pull --no-cache --tag resin/${JOB_NAME}:${REVISION} -f ${SCRIPTPATH}/${DOCKERFILE} ${SCRIPTPATH}
 
 # Tag
 docker tag -f resin/${JOB_NAME}:${REVISION} resin/${JOB_NAME}:latest


### PR DESCRIPTION
…build-env docker image.

We specify "--no-cache" when building the yocto-build-env docker image to get rid of errors during "docker run" such as this one:

Error response from daemon: could not find image: no such id: e34890d8e9bcb92938c0891f792b32bd83eec3ad1d50dad90eea779980e09664

where e34890d8e9bcb92938c0891f792b32bd83eec3ad1d50dad90eea779980e09664 does not exist on the machine doing the "docker run".

Signed-off-by: Florin Sarbu <florin@resin.io>