### PR TITLE
Dockerfile_yocto-build-env: Do not include SDL

### DIFF
--- a/automation/Dockerfile_yocto-build-env
+++ b/automation/Dockerfile_yocto-build-env
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 
 # Install the following utilities (required by poky)
-RUN apt-get update && apt-get install -y build-essential chrpath curl diffstat gcc-multilib gawk git-core libsdl1.2-dev locales texinfo unzip wget xterm cpio file python3 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y build-essential chrpath curl diffstat gcc-multilib gawk git-core locales texinfo unzip wget xterm cpio file python python3 && rm -rf /var/lib/apt/lists/*
 
 # Set the locale to UTF-8 for bulding with poky morty
 RUN locale-gen en_US.UTF-8


### PR DESCRIPTION
Yocto Morty can build a libsdl-native so there is no need for it in the docker image.

Also we install python 2.7 as it is explicitly needed by some packages. E.g. xcb-proto-native

Signed-off-by: Florin Sarbu <florin@resin.io>