### PR TITLE
Dockerfile_yocto-build-env: Add some packages for Pyro

### DIFF
--- a/automation/Dockerfile_yocto-build-env
+++ b/automation/Dockerfile_yocto-build-env
@@ -1,7 +1,9 @@
 FROM ubuntu:16.04
 
 # Install the following utilities (required by poky)
-RUN apt-get update && apt-get install -y build-essential chrpath curl diffstat gcc-multilib gawk git-core locales texinfo unzip wget xterm cpio file python python3 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y build-essential chrpath curl diffstat gcc-multilib gawk git-core locales \
+                                         texinfo unzip wget xterm cpio file python python3 openssh-client ping iproute2 \
+                                         && rm -rf /var/lib/apt/lists/*
 
 # Set the locale to UTF-8 for bulding with poky morty
 RUN locale-gen en_US.UTF-8


### PR DESCRIPTION
The Yocto Pyro build process is more strict about which packages
it requires, add packages for: ip, ping, scp, ssh

Signed-off-by: Will Newton <willn@resin.io>