### PR TITLE
Dockerfile_yocto-build-env: Use correct ubuntu package name for ping

### DIFF
--- a/automation/Dockerfile_yocto-build-env
+++ b/automation/Dockerfile_yocto-build-env
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 
 # Install the following utilities (required by poky)
 RUN apt-get update && apt-get install -y build-essential chrpath curl diffstat gcc-multilib gawk git-core locales \
-                                         texinfo unzip wget xterm cpio file python python3 openssh-client ping iproute2 \
+                                         texinfo unzip wget xterm cpio file python python3 openssh-client iputils-ping iproute2 \
                                          && rm -rf /var/lib/apt/lists/*
 
 # Set the locale to UTF-8 for bulding with poky morty

--- a/automation/jenkins_yocto-build-env.sh
+++ b/automation/jenkins_yocto-build-env.sh
@@ -19,7 +19,7 @@ fi
 docker build --pull --no-cache --tag resin/${JOB_NAME}:${REVISION} -f ${SCRIPTPATH}/${DOCKERFILE} ${SCRIPTPATH}
 
 # Tag
-docker tag -f resin/${JOB_NAME}:${REVISION} resin/${JOB_NAME}:latest
+docker tag resin/${JOB_NAME}:${REVISION} resin/${JOB_NAME}:latest
 
 # Push
 docker push resin/${JOB_NAME}:${REVISION}


### PR DESCRIPTION
Package ping is a virtual package so we use the actual providfer called iputils-ping

Signed-off-by: Florin Sarbu <florin@resin.io>