### PR TITLE
automation/jenkins_build.sh: Pull yocto-build-env

### DIFF
--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -210,6 +210,7 @@ mkdir -p $JENKINS_SSTATE_DIR
 # Run build
 docker stop $BUILD_CONTAINER_NAME 2> /dev/null || true
 docker rm --volumes $BUILD_CONTAINER_NAME 2> /dev/null || true
+docker pull resin/yocto-build-env
 docker run ${REMOVE_CONTAINER} \
     -v $WORKSPACE:/yocto/resin-board \
     -v $JENKINS_DL_DIR:/yocto/shared-downloads \


### PR DESCRIPTION
Do a docker pull on the resin/yocto-build-env image before
starting the build. This means we always get the latest version
of the image.

Signed-off-by: Will Newton <willn@resin.io>