### PR TITLE
Empty values to -a

### DIFF
--- a/build/barys
+++ b/build/barys
@@ -270,7 +270,7 @@ while [[ $# -ge 1 ]]; do
             if [ -z "$2" ]; then
                 log ERROR "\"$1\" argument needs a value."
             fi
-            if [ -z "$(echo "$2" | awk -F= '{print $2}')" ]; then
+            if echo "$2" | grep -vq '^[A-Za-z0-9_]*='; then
                 log ERROR "\"$2\" has the wrong argument format for \"$1\". Read help."
             fi
             ADDITIONAL_VARIABLES="$ADDITIONAL_VARIABLES $2"


### PR DESCRIPTION
I've stumbled on a fact that barys can't accept empty values to `-a`, i.e. `barys -a FOO=`. If I do `barys -a FOO=""` it makes an extra pair of quotation marks thus still not an empty value. Here is a quick fix of the condition so that it allows a `FOO=` form. The rest of the code should play nice and insert an empty string between the quotes.

Please review. Seems to work fine in my setup.