### PR TITLE
build/package.json: Set a valid license

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/resin-os/resin-yocto-scripts"
   },
   "author": "Resin.io <hello@resin.io>",
-  "license": "Unlicensed",
+  "license": "Apache-2.0",
   "dependencies": {
     "@resin.io/device-types": "^10.1.0",
     "coffee-script": "~1.10.0"


### PR DESCRIPTION
This fixes a warning during builds and also makes the code license
clearer.

Signed-off-by: Will Newton <willn@resin.io>