### PR TITLE
jenkins_build.sh: Use host's lib module

### DIFF
--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -217,6 +217,7 @@ docker run ${REMOVE_CONTAINER} \
     -v $JENKINS_DL_DIR:/yocto/shared-downloads \
     -v $JENKINS_SSTATE_DIR:/yocto/shared-sstate \
     -v $SSH_AUTH_SOCK:/tmp/ssh-agent \
+    -v /lib/modules:/lib/modules \
     -e SSH_AUTH_SOCK=/tmp/ssh-agent \
     -e BUILDER_UID=$(id -u) \
     -e BUILDER_GID=$(id -g) \


### PR DESCRIPTION
Docker might need to load various kernel modules so make them available at
runtime.

Signed-off-by: Andrei Gherzan <andrei@resin.io>