### PR TITLE
Allow to build a custom "production" resinos image

### DIFF
--- a/build/barys
+++ b/build/barys
@@ -434,7 +434,6 @@ else
     sed -i "s/.*RESIN_CONNECTABLE_ENABLE_SERVICES ?=.*/RESIN_CONNECTABLE_ENABLE_SERVICES ?= \"0\"/g" conf/local.conf
     sed -i "s/.*TARGET_REPOSITORY ?=.*/TARGET_REPOSITORY ?= \"\"/g" conf/local.conf
     sed -i "s/.*TARGET_TAG ?=.*/TARGET_TAG ?= \"\"/g" conf/local.conf
-    sed -i "s/.*DEVELOPMENT_IMAGE =.*/DEVELOPMENT_IMAGE = \"1\"/g" conf/local.conf
 fi
 if [ -n "$SUPERVISOR_TAG" ]; then
     sed -i "s/.*SUPERVISOR_TAG ?=.*/SUPERVISOR_TAG ?= \"$SUPERVISOR_TAG\"/g" conf/local.conf


### PR DESCRIPTION
We can already set the `--development-image` flag for barys to build a development image