### PR TITLE
barys: Don't error out if there is no fstype defined.

### DIFF
--- a/build/barys
+++ b/build/barys
@@ -494,10 +494,11 @@ else
         IMAGE=`jq -r '.yocto | select(.machine == '\"${machine}\"').image' $json`
         FSTYPE=`jq -r '.yocto | select(.machine == '\"${machine}\"').fstype' $json`
         if [ -z "$IMAGE" ] || [ -z "$FSTYPE" ] || [ "z$IMAGE" == "znull" ] || [ "z$FSTYPE" == "znull" ]; then
-          log ERROR "No target image and/or fstype defined for $machine."
-      fi
-        log "If build for $machine succeeded, final image should have been generated here:"
-        log "   $BUILD_DIR/tmp/deploy/images/$machine/$IMAGE-$machine.$FSTYPE"
+          log WARN "No target image and/or fstype defined for $machine. This is normal for generic builds which don't generate raw images."
+        else
+            log "If build for $machine succeeded, final image should have been generated here:"
+            log "   $BUILD_DIR/tmp/deploy/images/$machine/$IMAGE-$machine.$FSTYPE"
+        fi
     done
   done
 fi


### PR DESCRIPTION
There can be cases where there is no fstype. For example this is true when we
build generic image for resinOS in container. This patch makes barys only warn
if there is no fstype/image defined.

Signed-off-by: Andrei Gherzan <andrei@resin.io>