### PR TITLE
Allow additionnal variables that contains "-" char

### DIFF
--- a/build/barys
+++ b/build/barys
@@ -270,7 +270,7 @@ while [[ $# -ge 1 ]]; do
             if [ -z "$2" ]; then
                 log ERROR "\"$1\" argument needs a value."
             fi
-            if echo "$2" | grep -vq '^[A-Za-z0-9_]*='; then
+            if echo "$2" | grep -vq '^[A-Za-z0-9_-]*='; then
                 log ERROR "\"$2\" has the wrong argument format for \"$1\". Read help."
             fi
             ADDITIONAL_VARIABLES="$ADDITIONAL_VARIABLES $2"


### PR DESCRIPTION
This is useful for example to add variables suffixed with machine name, for example:
TARGET_REPOSITORY_genericx86-64=my.docker.repo/custom/targetimage