### PR TITLE
jenkins_build.sh: UI uses `docker-image` as deploy artefact

### DIFF
--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -60,8 +60,8 @@ deploy_build () {
 
 	test "$SLUG" = "edge" && return
 
-	if [ -z "$_deploy_artifact" ] && [ -z "$_deploy_flasher_artifact" ]; then
-		echo "[WARN] No deploy artifacts defined."
+	if [ "$_deploy_artifact" = "docker-image" ]; then
+		echo "[WARN] No artifacts to deploy. The images will be pushed to docker registry."
 		return
 	fi
 


### PR DESCRIPTION
When that is the case, the UI doesn't offer raw images for download.

Signed-off-by: Andrei Gherzan <andrei@resin.io>