### PR TITLE
Set dummy git credentials for "builder" user

### DIFF
--- a/automation/prepare-and-start.sh
+++ b/automation/prepare-and-start.sh
@@ -67,6 +67,12 @@ until docker info >/dev/null 2>&1; do
 done
 echo "[INFO] Docker was initialized."
 
+sudo -H -u builder git config --global user.name "Resin Builder"
+sudo -H -u builder git config --global user.email "buildy@builder.com"
+echo "[INFO] The configured git credentials for user builder are:"
+sudo -H -u builder git config --get user.name
+sudo -H -u builder git config --get user.email
+
 # Start barys with all the arguments requested
 echo "[INFO] Running build as builder user..."
 sudo -H -u builder /yocto/resin-board/resin-yocto-scripts/build/barys $@ &


### PR DESCRIPTION
In some cases Yocto wants to initialize git repos, but it will fail because
git credentials are missing.
This commit sets dummy git credentials for user "builder" before starting a build.

Signed-off-by: Sebastian Panceac <sebastian@resin.io>