### PR TITLE
Dockerfile_yocto-build-env: Add dos2unix to container

### DIFF
--- a/automation/Dockerfile_yocto-build-env
+++ b/automation/Dockerfile_yocto-build-env
@@ -18,6 +18,9 @@ RUN echo "deb https://deb.nodesource.com/$NODE_VERSION $DISTRO main" | tee /etc/
   echo "deb-src https://deb.nodesource.com/$NODE_VERSION $DISTRO main" | tee -a /etc/apt/sources.list.d/nodesource.list
 RUN apt-get update && apt-get install -y jq nodejs sudo && rm -rf /var/lib/apt/lists/*
 
+# Additional host packages required by various BSP layers
+RUN apt-get update && apt-get install -y dos2unix && rm -rf /var/lib/apt/lists/*
+
 # Install docker
 # https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
 RUN apt-get update && apt-get install -y iptables procps e2fsprogs xfsprogs xz-utils git kmod && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Various BSPs may need additional host tools available.
for instance, we are adding now dos2unix because it is needed by
https://github.com/varigit/meta-variscite-fslc/blob/rocko/recipes-connectivity/wlconf/wlconf.bb#L35

Signed-off-by: Florin Sarbu <florin@resin.io>