### PR TITLE
Unify managed/unmanaged builds

### DIFF
--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -179,22 +179,14 @@ Run with -h or --help for a complete list of arguments.\n"
 	exit 1
 fi
 
-if [ "$buildFlavor" = "managed-dev" ]; then
-	BARYS_ARGUMENTS_VAR="$BARYS_ARGUMENTS_VAR --resinio"
+if [ "$buildFlavor" = "dev" ]; then
 	BARYS_ARGUMENTS_VAR="$BARYS_ARGUMENTS_VAR --development-image"
 	DEVELOPMENT_IMAGE=yes
-	RESIN_MANAGED_IMAGE=yes
-elif [ "$buildFlavor" = "managed-prod" ]; then
-	BARYS_ARGUMENTS_VAR="$BARYS_ARGUMENTS_VAR --resinio"
+elif [ "$buildFlavor" = "prod" ]; then
 	DEVELOPMENT_IMAGE=no
-	RESIN_MANAGED_IMAGE=yes
-elif [ "$buildFlavor" = "unmanaged-dev" ]; then
-	BARYS_ARGUMENTS_VAR="$BARYS_ARGUMENTS_VAR --development-image"
-	DEVELOPMENT_IMAGE=yes
-	RESIN_MANAGED_IMAGE=no
-elif [ "$buildFlavor" = "unmanaged-prod" ]; then
-	DEVELOPMENT_IMAGE=no
-	RESIN_MANAGED_IMAGE=no
+else
+	echo "[ERROR] No such build flavor: $buildFlavor."
+	exit 1
 fi
 
 # When supervisorTag is provided, you the appropiate barys argument
@@ -309,20 +301,12 @@ deploy_to_s3() {
 	if [ "$deployTo" = "production" ]; then
 		_s3_access_key=${PRODUCTION_S3_ACCESS_KEY}
 		_s3_secret_key=${PRODUCTION_S3_SECRET_KEY}
-		if [ "$RESIN_MANAGED_IMAGE" = "yes" ]; then
-			_s3_bucket=resin-production-img-cloudformation/images
-		else
-			_s3_bucket=resin-production-img-cloudformation/resinos
-		fi
+		_s3_bucket=resin-production-img-cloudformation/images
 		S3_SYNC_OPTS="$S3_SYNC_OPTS --skip-existing"
 	elif [ "$deployTo" = "staging" ]; then
 		_s3_access_key=${STAGING_S3_ACCESS_KEY}
 		_s3_secret_key=${STAGING_S3_SECRET_KEY}
-		if [ "$RESIN_MANAGED_IMAGE" = "yes" ]; then
-			_s3_bucket=resin-staging-img/images
-		else
-			_s3_bucket=resin-staging-img/resinos
-		fi
+		_s3_bucket=resin-staging-img/images
 	else
 		echo "[ERROR] Refusing to deploy to anything other than production or master."
 		exit 1
@@ -376,7 +360,7 @@ EOSU
 # Deploy
 if [ "$deploy" = "yes" ]; then
 	echo "[INFO] Starting deployment..."
-	if [ "$DEVELOPMENT_IMAGE" = "no" ] && [ "$RESIN_MANAGED_IMAGE" = "yes" ] && [ "$DEVICE_STATE" != "DISCONTINUED" ]; then
+	if [ "$DEVELOPMENT_IMAGE" = "no" ] && [ "$DEVICE_STATE" != "DISCONTINUED" ]; then
 		deploy_resinhup_to_registries
 	fi
 

--- a/build/barys
+++ b/build/barys
@@ -72,10 +72,6 @@ function help {
     echo -e "\t\t The format of the arguments need to be VARIABLE=VALUE ."
     echo -e "\t\t VALUE doesn't support white spaces."
 
-    echo -e "\t--resinio"
-    echo -e "\t\t Set build configuration for resin-io."
-    echo -e "\t\t Default: no."
-
     echo -e "\t--supervisor-tag"
     echo -e "\t\t Use a specific supervisor tag."
     echo -e "\t\t Default: production."
@@ -278,9 +274,6 @@ while [[ $# -ge 1 ]]; do
         --build-history)
             BUILD_HISTORY=yes
             ;;
-        --resinio)
-            RESINIO_CONFIGURATION=yes
-            ;;
         -a|--additional-variable)
             if [ -z "$2" ]; then
                 log ERROR "\"$1\" argument needs a value."
@@ -439,19 +432,6 @@ if [ -n "$SHARED_DOWNLOADS" ]; then
 fi
 if [ -n "$SHARED_SSTATE" ]; then
     sed -i "s#.*SSTATE_DIR ?=.*#SSTATE_DIR ?= \"$SHARED_SSTATE\"#g" conf/local.conf
-fi
-if [ "x$RESINIO_CONFIGURATION" == "xyes" ]; then
-    # ResinIO build configuration
-    sed -i "s/.*RESIN_CONNECTABLE ?=.*/RESIN_CONNECTABLE ?= \"1\"/g" conf/local.conf
-    sed -i "s/.*RESIN_CONNECTABLE_ENABLE_SERVICES ?=.*/RESIN_CONNECTABLE_ENABLE_SERVICES ?= \"1\"/g" conf/local.conf
-    sed -i "s/^TARGET_REPOSITORY ?=.*/#TARGET_REPOSITORY ?= \"\"/g" conf/local.conf
-    sed -i "s/^TARGET_TAG ?=.*/#TARGET_TAG ?= \"\"/g" conf/local.conf
-else
-    # ResinOS build configuration
-    sed -i "s/.*RESIN_CONNECTABLE ?=.*/RESIN_CONNECTABLE ?= \"1\"/g" conf/local.conf
-    sed -i "s/.*RESIN_CONNECTABLE_ENABLE_SERVICES ?=.*/RESIN_CONNECTABLE_ENABLE_SERVICES ?= \"0\"/g" conf/local.conf
-    sed -i "s/.*TARGET_REPOSITORY ?=.*/TARGET_REPOSITORY ?= \"\"/g" conf/local.conf
-    sed -i "s/.*TARGET_TAG ?=.*/TARGET_TAG ?= \"\"/g" conf/local.conf
 fi
 if [ -n "$SUPERVISOR_TAG" ]; then
     sed -i "s/.*SUPERVISOR_TAG ?=.*/SUPERVISOR_TAG ?= \"$SUPERVISOR_TAG\"/g" conf/local.conf

--- a/build/barys.changelog
+++ b/build/barys.changelog
@@ -1,3 +1,4 @@
+- Unify managed/unmanaged images as per 2.14.0 resinOS changes
 - Rename RESIN_SDIMG_COMPRESSION to RESIN_RAW_IMG_COMPRESSION to follow resinOS
 - Implement --resinio and make ResinOS default build configuration
 - Add support for injecting random local.conf variables


### PR DESCRIPTION
Starting with resinOS 2.14.0 the managed and managed builds are now
unified. Remove the configuration for such build flavors.

Signed-off-by: Andrei Gherzan <andrei@resin.io>