### PR TITLE
barys: pass DEVELOPMENT_IMAGE = 0 when -d is not passed

### DIFF
--- a/build/barys
+++ b/build/barys
@@ -425,6 +425,7 @@ source ${SCRIPTPATH}/../../layers/poky/oe-init-build-env ${SCRIPTPATH}/../../${B
 if [ "x$DEVELOPMENT_IMAGE" == "xyes" ]; then
     sed -i "s/.*DEVELOPMENT_IMAGE =.*/DEVELOPMENT_IMAGE = \"1\"/g" conf/local.conf
 else
+    sed -i "s/.*DEVELOPMENT_IMAGE =.*/DEVELOPMENT_IMAGE = \"0\"/g" conf/local.conf
     # Always activate resinhup bundles in production builds
     sed -i "s/.*RESINHUP ?=.*/RESINHUP ?= \"yes\"/g" conf/local.conf
 fi


### PR DESCRIPTION
Currently if barys is run with -d, DEVELOPMENT_IMAGE is
set to 1 in local.conf. If barys is run next time without
-d, DEVELOPMENT_IMAGE is not set back to 0. Hence the
generated image is still a dev image with serial enabled
etc.

Change-type: Patch
Changelog-entry: Fix for barys with -d and without -d

Signed-off-by: Zubair Lutfullah Kakakhel <zubair@resin.io>