### PR TITLE
Dockerfile_yocto-build-env: Add openssl-dev

### DIFF
--- a/automation/Dockerfile_yocto-build-env
+++ b/automation/Dockerfile_yocto-build-env
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 
 # Install the following utilities (required by poky)
 RUN apt-get update && apt-get install -y build-essential chrpath curl diffstat gcc-multilib gawk git-core locales \
-                                         texinfo unzip wget xterm cpio file python python3 openssh-client iputils-ping iproute2 \
+                                         texinfo unzip wget xterm cpio file python python3 openssh-client libssl-dev iputils-ping iproute2 \
                                          && rm -rf /var/lib/apt/lists/*
 
 # Set the locale to UTF-8 for bulding with poky morty


### PR DESCRIPTION
This package is needed for compiling kernel-modules-headers
on newer kernels (encountered on 4.16)

Signed-off-by: Florin Sarbu <florin@resin.io>